### PR TITLE
core(user): add delete own user data for non-admin user

### DIFF
--- a/cmd/api/server/handlers/httpHandlersAdmin.go
+++ b/cmd/api/server/handlers/httpHandlersAdmin.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
+// Type to cast for admin user
 type UserDataAsAdmin struct {
 	ID        string      `gorm:"type:uuid;primary_key"`
 	CreatedAt time.Time   `json:"created_at"`

--- a/cmd/api/server/routes.go
+++ b/cmd/api/server/routes.go
@@ -66,6 +66,8 @@ func Routes(app *application.Application) http.Handler {
 
 		// Profile image upload
 		mux.Post("/upload/profile", handlers.UploadProfileImage(app)) // Upload user profile image
+
+		mux.Delete("/user/{user_id}", handlers.DeleteOwnUserData(app))
 	})
 
 	mux.Route("/auth/api/admin", func(mux chi.Router) {

--- a/internal/models/Users.go
+++ b/internal/models/Users.go
@@ -17,7 +17,7 @@ type User struct {
 	LastName  string    `json:"last_name"`
 	Email     string    `json:"email"`
 	Password  string    `json:"password"`
-	Mode      Mode      `gorm:"foreignKey:UserID" json:"mode,omitempty"`
+	Mode      Mode      `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE;" json:"mode,omitempty"`
 }
 
 type Mode struct {

--- a/internal/repositories/Mode.go
+++ b/internal/repositories/Mode.go
@@ -52,11 +52,23 @@ func (r *GORMRepo) DeleteModeByID(id int) error {
 	}
 
 	tx := r.DB.Begin()
+	defer func() {
+		if r := recover(); r != nil {
+			tx.Rollback()
+		}
+	}()
+
 	tx.SavePoint("beforeDeleteMode")
+
 	if err := tx.Delete(&mode, "id = ?", id).Error; err != nil {
 		tx.RollbackTo("beforeDeleteMode")
 		return err
 	}
+
+	if err := tx.Commit().Error; err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Added handler func, route and new constraints in the user model. This would allow non-admin users to delete their account if they want.